### PR TITLE
feat(BCS-24) - allow web crawlers

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /


### PR DESCRIPTION
Add a robots.txt to public that will allow all web crawlers. This is needed for PWA's and also will help google give us more visibility.